### PR TITLE
fix: Pull upstream fix to not cache UDR URI

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/udm.git
     source-type: git
-    source-commit: 8964b762254765717d3bf705f979a35b6cd5f58e
+    source-commit: 654e165ee8da01db986fdd9fb4125d3554f35818
     build-snaps:
       - go/1.21/stable
     stage-packages:


### PR DESCRIPTION
# Description

Pull upstream fix that ignores the cache of the UDR URI, fixing problems when the UDR crashes and changes IP.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
