### PR TITLE
fix: Update workload version to 1.4.1

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: sdcore-udm
 base: bare
 build-base: ubuntu@22.04
-version: '1.4.0'
+version: '1.4.1'
 summary: SD-Core UDM
 description: SD-Core UDM
 license: Apache-2.0
@@ -14,7 +14,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/udm.git
     source-type: git
-    source-tag: v1.4.0
+    source-tag: v1.4.1
     build-snaps:
       - go/1.21/stable
     stage-packages:


### PR DESCRIPTION
# Description

The upstream UDM is updated to fix security error during compilation by PR: https://github.com/omec-project/udm/pull/95.
This PR bumps the workload version to get the fix and solves the issue https://github.com/canonical/sdcore-amf-rock/issues/22.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
