### PR TITLE
chore: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security policy
+
+To report a security issue, file a [Private Security Report](https://github.com/canonical/sdcore-udm-rock/security/advisories/new)
+with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about
+what you can expect when you contact us and what we expect from you.


### PR DESCRIPTION
# Description

Here we add the security policy as it is now mandated for every public repository.

## Rationale
> Any public repository must also include a SECURITY.md file in the root directory, which educates users/contributors on how to report a security concern. An example template is [here](https://docs.google.com/document/d/1wAO9ejAYcTpG76xwR822RZCnxfTMkf_caODWUL7BldE/edit?pli=1) and the LXD SECURITY.md file can be seen [here](https://github.com/canonical/lxd/blob/main/SECURITY.md) as a reference.

## Reference
- https://docs.google.com/document/d/1RolsiWCWhM-sVmHFjLt-Mq5yKcgQJ8GLXssGJREjSL0/edit
- https://docs.google.com/document/d/1wAO9ejAYcTpG76xwR822RZCnxfTMkf_caODWUL7BldE/edit?pli=1

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
